### PR TITLE
Add pt_BR.lang

### DIFF
--- a/ArcUI-Index/texts/pt_BR.lang
+++ b/ArcUI-Index/texts/pt_BR.lang
@@ -1,0 +1,294 @@
+## - Settings Sections Title -
+## Note: Character case doesn't matter since the font will outputs
+##       all the same characters.
+arc-ui.settingtitle.about=Sobre a ARC-UI
+arc-ui.settingtitle.about-config=Configurações
+arc-ui.settingtitle.about-changelog=Registro de mudanças
+arc-ui.settingtitle.accessibility-tts=Configurações de texto em fala
+arc-ui.settingtitle.accessibility-visuality=Configurações de visibilidade
+arc-ui.settingtitle.account=Configurações de conta
+arc-ui.settingtitle.account-alt=Configurações adicionais
+arc-ui.settingtitle.creator=Configurações de criador
+arc-ui.settingtitle.gamepad=Configurações de controle
+arc-ui.settingtitle.howtoplay=Como jogar
+arc-ui.settingtitle.keyboardandmouse=Configurações de teclado e mouse
+arc-ui.settingtitle.lang=Configurações de idioma
+arc-ui.settingtitle.sound=Configurações de som
+arc-ui.settingtitle.sound-main=Configurações principais
+arc-ui.settingtitle.touch=Configurações dos controles de toque
+arc-ui.settingtitle.video-interface=Configurações de interface
+arc-ui.settingtitle.video-graphic=Configurações de gráficos
+arc-ui.settingtitle.video-experiment=Configurações experimentais
+
+## - Start Section -
+## Note: Character case doesn't matter since the font will outputs
+##       probably the same.
+## > Regular ( Start screen & Pause screen )
+arc-ui.mainmenu.regular.start=JOGAR
+arc-ui.mainmenu.regular.setting=OPÇÕES
+arc-ui.mainmenu.regular.skin=CRIADOR DE PERSONAGEM
+arc-ui.mainmenu.regular.achievement=CONQUISTAS
+arc-ui.mainmenu.regular.marketplace=MARKETPLACE
+arc-ui.mainmenu.regular.more=MAIS
+arc-ui.mainmenu.regular.exit=SAIR DO JOGO
+## > Pause ( Pause screen only )
+arc-ui.mainmenu.pause.start=CONTINUAR JOGO
+arc-ui.mainmenu.pause.exit=SALVAR E SAIR
+
+## - Safe zone screen -
+arc-ui.setting.safezone.title.main=Configurações da Zona Segura
+arc-ui.setting.safezone.title.exp=Configurações experimentais
+arc-ui.setting.safezone.main=Ajuste quando a tela do jogo não se encaixar bem em sua tela. 
+arc-ui.setting.safezone.exp=Não intencionalmente era uma opção oculta, era para um recurso da versão de console
+arc-ui.setting.safezone.allcorner=§7Expandir e diminuir em todos os cantos
+arc-ui.setting.safezone.horizontal=§7Expandir e diminuir entre os lados esquerdo e direito
+arc-ui.setting.safezone.vertical=§7Expandir entre a parte superior e inferior
+arc-ui.setting.safezone.horizontalpos=§7Mover a tela entre a esquerda e a direita (EXP: não funcionará se as configurações não experimentais a seguir forem padrão)
+arc-ui.setting.safezone.verticalpos=§7Mover a tela entre a parte superior e inferior (EXP: não funcionará se as configurações não experimentais a seguir forem padrão)
+
+## - Sound section -
+arc-ui.setting.sound.main=§7Volume do jogo - Afeta o volume do jogo desde das músicas aos sons. Observe que esta opção não afeta as outras opções de volume!
+arc-ui.setting.sound.music=§7Volume das músicas - Afeta o volume relacionado às músicas, como: as do menu principal, do mundo superior, do modo criativo etc.	# Overworld translation (mundo superior) taken from Xbox Achievements
+arc-ui.setting.sound.sound=§7Volume dos sons - Afeta o volume relacionado aos sons, como andar, quebrar blocos, tocar discos etc.
+arc-ui.setting.sound.ambient=§7Volume do ambiente - Afeta o volume relacionado aos sons do ambiente, como os das cavernas e assim por diante 
+arc-ui.setting.sound.block=§7Volume dos blocos - Afeta o volume relacionado aos sons dos blocos, como andar sobre eles, quebrá-los e assim por diante.
+arc-ui.setting.sound.hostile=§7Volume dos sons de criaturas hostis.
+arc-ui.setting.sound.neutral=§7Volume dos sons de criaturas amigáveis.
+arc-ui.setting.sound.player=§7Volume dos sons de dano do jogador.
+arc-ui.setting.sound.record=§7Volume dos discos.
+arc-ui.setting.sound.weather=§7Volume dos sons de clima, chuva e tempestade.
+arc-ui.setting.sound.tts=§7Volume da conversão de texto em fala
+
+## - About section -
+arc-ui.settingtitle.changelog.config=Detalhes de configuração
+arc-ui.setting.changelogtitle.enabled=Todos os registros de mudanças ficam aqui, você pode clicar nos itens da lista decrescente para vê-los!	# Not sure if the translation of “dropdown order” is “lista decrescente” in this context
+arc-ui.setting.changelogtitle.disabled=O registro de mudanças na configuração está §cdisabled.§f Você ainda pode checar o registro de mudanças de Arcdustry-UI em §e"ARC-UI/changelog.txt"
+
+## - Changelog section V2 -
+arc-ui.setting.changelogv2desc.addition-update=§a§l[ -- ADIÇÕES / ATUALIZAÇÕES -- ]
+arc-ui.setting.changelogv2desc.bug-fixes=§a§l[ -- CORREÇÕES DE BUGS -- ]
+arc-ui.setting.changelogv2desc.changes=§a§l[ -- AJUSTES -- ]
+
+## video section
+arc-ui.setting.video-experiment.warn=§7§oAs opções a seguir são experimentais e, definitivamente, não foram criadas para serem ativadas em qualquer plataforma. Vários opções daqui estão ativadas em poucas plataformas. Elas podem causar os seguintes problemas: crashes inesperados, baixo desempenho ou a opção não funcionará inteiramente. Tenha cuidado em que você está fazendo, porque não sou responsável por elas.
+
+# Translator note: all the changelog remains untranslated because is too long and I do not see reason to translate it. Maybe in the future I can change my mind.
+## v0.1-alpha-1
+arc-ui.section.changelogv2desc.v0-1-alpha-1.001=§o× Released in - Oct 3, 2022
+arc-ui.section.changelogv2desc.v0-1-alpha-1.002=§o× Supported - 1.19.30+
+arc-ui.section.changelogv2desc.v0-1-alpha-1.003=§e× -- Initial Release for github! --
+arc-ui.section.changelogv2desc.v0-1-alpha-1.004=§e× Many features from config such as appearance aren't properly added. Don't issue for such unfinished features for now.
+arc-ui.section.changelogv2desc.v0-1-alpha-1.005=§7[§e=§7]§f Modified Start Screen
+arc-ui.section.changelogv2desc.v0-1-alpha-1.006=§7[§e=§7]§f Modified Kernel Config Checker
+arc-ui.section.changelogv2desc.v0-1-alpha-1.007=§7[§e=§7]§f Added Debug screen for kernel
+arc-ui.section.changelogv2desc.v0-1-alpha-1.008=§7[§e=§7]§f Added "contents.json" for better checking and don't add any unnecessary files.
+
+## v0.1-alpha-2
+arc-ui.section.changelogv2desc.v0-1-alpha-2.001=§o× Released in - Nov 10, 2022
+arc-ui.section.changelogv2desc.v0-1-alpha-2.002=§o× Supported - 1.19.30+
+arc-ui.section.changelogv2desc.v0-1-alpha-2.003=§e× -- Re-working UI's --
+arc-ui.section.changelogv2desc.v0-1-alpha-2.004=§e× Improvements and bug fixes, Appearance's is added. Working alot with config system and introduction of world screen.
+arc-ui.section.changelogv2desc.v0-1-alpha-2.005=§7[§a+§7]§f Added/Modified World Screen
+arc-ui.section.changelogv2desc.v0-1-alpha-2.006=§7[§a+§7]§f Adjustments to kernel config
+arc-ui.section.changelogv2desc.v0-1-alpha-2.007=§7[§a+§7]§f Massive improvements to templates
+arc-ui.section.changelogv2desc.v0-1-alpha-2.008=§7[§a+§7]§f Added few customization in configuration
+arc-ui.section.changelogv2desc.v0-1-alpha-2.009=§7[§a+§7]§f Optimizations
+arc-ui.section.changelogv2desc.v0-1-alpha-2.010=§7[§a+§7]§f Revamped config file to look more visually
+
+## v0.1-alpha-2.1
+arc-ui.section.changelogv2desc.v0-1-alpha-2-1.001=§o× Released in - Nov 12, 2022
+arc-ui.section.changelogv2desc.v0-1-alpha-2-1.002=§o× Supported - 1.19.30+
+arc-ui.section.changelogv2desc.v0-1-alpha-2-1.003=§e× -- First Hotfix --
+arc-ui.section.changelogv2desc.v0-1-alpha-2-1.004=§e× Improvements and bug fixes
+arc-ui.section.changelogv2desc.v0-1-alpha-2-1.005=§7[§a+§7]§f Enabled Play Screen (World Sector), should able to play the world now
+arc-ui.section.changelogv2desc.v0-1-alpha-2-1.006=§7[§a+§7]§f Adjustments to incompatible backgrounds
+arc-ui.section.changelogv2desc.v0-1-alpha-2-1.007=§7[§a+§7]§f Dialog Concepts
+
+## v0.1-alpha-2.2
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.001=§o× Released in - Nov 16, 2022
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.002=§o× Supported - 1.19.30+
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.003=§e× -- Progress --
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.004=§e× Improvements and concepts art are being added. Arcaea's background will be removed soon hopefully.
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.005=§7[§e=§7]§f Play Screen (World Section) 85% Complete
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.006=§7[§e=§7]§f Play Screen 15% Complete
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.007=§7[§a+§7]§f Improvements to Play Screen
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.008=§7[§a+§7]§f Added the concepts buttons
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.009=§7[§a+§7]§f Moved Player Screen (World Section) to its own section folder
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.010=§7[§a+§7]§f Temporarily disabled "contents.json" order to make development easier
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.011=§7[§a+§7]§f Added Temporarily modified vanilla buttons
+arc-ui.section.changelogv2desc.v0-1-alpha-2-2.012=§7[§a+§7]§f Removed couples of unused files
+
+## v0.1-alpha-2.3
+arc-ui.section.changelogv2desc.v0-1-alpha-2-3.001=§o× Released in - Nov 23, 2022
+arc-ui.section.changelogv2desc.v0-1-alpha-2-3.002=§o× Supported - 1.19.30+
+arc-ui.section.changelogv2desc.v0-1-alpha-2-3.003=§e× -- UI Updates --
+arc-ui.section.changelogv2desc.v0-1-alpha-2-3.004=§e× Improvements to its stability, removed concepts art. few UI components are being added. No configuration update, this is purely play screen.
+arc-ui.section.changelogv2desc.v0-1-alpha-2-3.005=§7[§a+§7]§f Play Screen - Added Tabs for allowing to play servers and realms. World screen is completed!
+arc-ui.section.changelogv2desc.v0-1-alpha-2-3.006=§7[§a+§7]§f Play Screen 65% Complete
+arc-ui.section.changelogv2desc.v0-1-alpha-2-3.007=§7[§a+§7]§f Optimized few UI's to work alot better
+arc-ui.section.changelogv2desc.v0-1-alpha-2-3.008=§7[§a+§7]§f Added the concepts button fully in the play screen
+arc-ui.section.changelogv2desc.v0-1-alpha-2-3.009=§7[§a+§7]§f Added Vanilla's controller scheme support
+
+## v0.1-alpha-2.4
+arc-ui.section.changelogv2desc.v0-1-alpha-2-4.001=§o× Released in - Nov 27, 2022
+arc-ui.section.changelogv2desc.v0-1-alpha-2-4.002=§o× Supported - 1.19.40+
+arc-ui.section.changelogv2desc.v0-1-alpha-2-4.003=§e× -- UI Updates --
+arc-ui.section.changelogv2desc.v0-1-alpha-2-4.004=§e× Improvements to its stability and better visuality.
+arc-ui.section.changelogv2desc.v0-1-alpha-2-4.005=§7[§a+§7]§f Added better visuals on play screen's tab, added icons on selection buttons.
+arc-ui.section.changelogv2desc.v0-1-alpha-2-4.006=§7[§a+§7]§f Friends/Realms section is finished!
+arc-ui.section.changelogv2desc.v0-1-alpha-2-4.007=§7[§a+§7]§f Play screen are 80% completed!
+arc-ui.section.changelogv2desc.v0-1-alpha-2-4.008=§7[§a+§7]§f Removed the background because i don't want any DMCA
+arc-ui.section.changelogv2desc.v0-1-alpha-2-4.009=§7[§a+§7]§f Optimizations and few tweaks
+
+## v0.2-alpha-1
+arc-ui.section.changelogv2desc.v0-2-alpha-1.001=§o× Released in - Dec 14, 2022
+arc-ui.section.changelogv2desc.v0-2-alpha-1.002=§o× Supported - 1.19.40+
+arc-ui.section.changelogv2desc.v0-2-alpha-1.003=§e× -- Rewrite and Beyond Update --
+arc-ui.section.changelogv2desc.v0-2-alpha-1.004=§e× This update inculdes whole rewritten version of Arc-UI. as well recreate better configs and stuff for better optimiziton and massive improvement for low-end devices.
+arc-ui.section.changelogv2desc.v0-2-alpha-1.005=§e× Since i've switched from Acode to Neovim, i've able to create comments and massive improvement to my coding experience. which, result better productitiy.
+arc-ui.section.changelogv2desc.v0-2-alpha-1.006=§e× Expect faster update and code improvement for now.
+arc-ui.section.changelogv2desc.v0-2-alpha-1.007=§7[§a+§7]§f Complete rewrite from scratch.
+arc-ui.section.changelogv2desc.v0-2-alpha-1.008=§7[§a+§7]§f Assets UI files may now switch from .json to .jsonc for comments
+
+## v1.0-prebeta & mcpedl release
+arc-ui.section.changelogv2desc.v1-0-prebeta.001=§o× Released in - Feb 18, 2023
+arc-ui.section.changelogv2desc.v1-0-prebeta.002=§o× Supported - 1.19.50+
+arc-ui.section.changelogv2desc.v1-0-prebeta.003=§e× -- The beginnings --
+arc-ui.section.changelogv2desc.v1-0-prebeta.004=§e× Finally, after 7 months of scraping works and many thing, ARC-UI is finally released on MCPEDL! Heres what new
+arc-ui.section.changelogv2desc.v1-0-prebeta.005=§7[§a+§7]§f A Complete rework UI inspired by Valve's source game built-in steam deck ui
+arc-ui.section.changelogv2desc.v1-0-prebeta.006=§7[§a+§7]§f Every screen is bought in good feels of controller usage
+arc-ui.section.changelogv2desc.v1-0-prebeta.007=§7[§a+§7]§f Massive improvements into configuration system, although. No functional features are being added until next update
+arc-ui.section.changelogv2desc.v1-0-prebeta.008=§7[§a+§7]§f Massively optimized! using the less resources as possible while maintaining vanilla feels
+arc-ui.section.changelogv2desc.v1-0-prebeta.009=§7[§a+§7]§f A Rewrite from scratch, features that from previous Arc-UI version is no longer exists. such as - Huge configuration functionalities, Better theme customization system, the use of "contents.json", Better Play screen sections ( did a rewrite in this ver ), Lynxsium/OverwhelmUI leftovers and no more code comments
+arc-ui.section.changelogv2desc.v1-0-prebeta.010=§7[§a+§7]§f Expect every screens has a function! :D
+arc-ui.section.changelogv2desc.v1-0-prebeta.011=§7[§e=§7]§f Restart is required to take custom fonts in effect
+arc-ui.section.changelogv2desc.v1-0-prebeta.012=§7[§e=§7]§f Pocket UI is not recommended, because this is built-in Classic UI ( I hope i could support it in the future lols )
+arc-ui.section.changelogv2desc.v1-0-prebeta.013=§7[§c-§7]§f No Controller/Keyboard Icons on every screen
+arc-ui.section.changelogv2desc.v1-0-prebeta.014=§7[§c-§7]§f Controller selection highlights is abit, not friendly yet
+arc-ui.section.changelogv2desc.v1-0-prebeta.015=§7[§c-§7]§f Lawnmower is no longer there :(
+arc-ui.section.changelogv2desc.v1-0-prebeta.016=§7[§c-§7]§f Expect issues that can happens by the usage of controllers
+arc-ui.section.changelogv2desc.v1-0-prebeta.017=§7[§a+§7]§f Touch and Keyboard/Mouse is supported
+
+## v1.0-beta-1 & bad release, causes crashes
+arc-ui.section.changelogv2desc.v1-0-beta-1.001=§o× Released in - Feb 22, 2023
+arc-ui.section.changelogv2desc.v1-0-beta-1.002=§o× Supported - 1.19.50+
+arc-ui.section.changelogv2desc.v1-0-beta-1.003=§e× -- Changes stuff before closing --
+arc-ui.section.changelogv2desc.v1-0-beta-1.004=§e× Few tweaks needs to be changed. and yes, new stuff too
+arc-ui.section.changelogv2desc.v1-0-beta-1.005=§7[§a+§7]§f Added Content log history in ARC-UI treatment
+arc-ui.section.changelogv2desc.v1-0-beta-1.006=§7[§a+§7]§f Added Toggle highlights for visibilities, controller/k&m can see the toggle highlights now.
+arc-ui.section.changelogv2desc.v1-0-beta-1.007=§7[§a+§7]§f Quality life changes alongside with performance improvements
+arc-ui.section.changelogv2desc.v1-0-beta-1.008=§7[§a+§7]§f Fixed a bug where it can indefinitely kills the setting screen ultimately making it useless
+arc-ui.section.changelogv2desc.v1-0-beta-1.009=§7[§a+§7]§f Fixed some issues with coordinate shortcuts on keyboard and creator section
+arc-ui.section.changelogv2desc.v1-0-beta-1.010=§7[§a+§7]§f Added close (X) button on couple of screens for mobile user
+arc-ui.section.changelogv2desc.v1-0-beta-1.011=§7[§e=§7]§f Pause screen is tweaked to have the same offset as start screen
+arc-ui.section.changelogv2desc.v1-0-beta-1.012=§7[§e=§7]§f Common elements changes for making development more easier
+arc-ui.section.changelogv2desc.v1-0-beta-1.013=§7[§e=§7]§f Code Cleaning
+arc-ui.section.changelogv2desc.v1-0-beta-1.014=§7[§c-§7]§f Disabled configuration system until I'll properly implement it.
+
+## v1.0-beta-2 & immediate hotfix
+arc-ui.section.changelogv2desc.v1-0-beta-2.001=§o× Released in - May 6, 2023
+arc-ui.section.changelogv2desc.v1-0-beta-2.002=§o× Supported - 1.19.50+
+arc-ui.section.changelogv2desc.v1-0-beta-2.003=§e× -- Plastic chair shall rise --
+arc-ui.section.changelogv2desc.v1-0-beta-2.004=§e× Quality life changes and so on
+arc-ui.section.changelogv2desc.v1-0-beta-2.005=§7[§a+§7]§f Adjusted bottom bar, should look really decent now
+arc-ui.section.changelogv2desc.v1-0-beta-2.006=§7[§a+§7]§f Adjusted Users area in start and pause screen
+arc-ui.section.changelogv2desc.v1-0-beta-2.007=§7[§a+§7]§f Fixed a crashes with missing fonts
+arc-ui.section.changelogv2desc.v1-0-beta-2.008=§7[§a+§7]§f Finalized 'account' and 'general' settings sections
+arc-ui.section.changelogv2desc.v1-0-beta-2.009=§7[§a+§7]§f Adjusted settings line bar
+arc-ui.section.changelogv2desc.v1-0-beta-2.010=§7[§a+§7]§f Added highlights for pause screen navigations
+arc-ui.section.changelogv2desc.v1-0-beta-2.011=§7[§a+§7]§f Added funny looking moving lawnmower
+arc-ui.section.changelogv2desc.v1-0-beta-2.012=§7[§a+§7]§f Common elements changes for making development more easier
+arc-ui.section.changelogv2desc.v1-0-beta-2.013=§7[§a+§7]§f About/Changelog screen are now officially has changelog! can also be disabled in configurations if the settings is loading more time than what it should be
+arc-ui.section.changelogv2desc.v1-0-beta-2.014=§7[§a+§7]§f Optimization and improvements and code cleaning
+arc-ui.section.changelogv2desc.v1-0-beta-2.015=§7[§a+§7]§f Few Experiment features being added
+
+## v1.0 - full release
+arc-ui.section.changelogv2desc.v1-0.001=§o× Released in - Mar 10, 2023
+arc-ui.section.changelogv2desc.v1-0.002=§o× Supported - 1.19.50+
+arc-ui.section.changelogv2desc.v1-0.003=§e× -- It's just a beginnings --
+arc-ui.section.changelogv2desc.v1-0.004=§e× Arc-UI are finally out of beta, with cool list of features!
+arc-ui.section.changelogv2desc.v1-0.005=§7[§a+§7]§f Revamped Sound screen with icons, descriptions and better calgory
+arc-ui.section.changelogv2desc.v1-0.006=§7[§a+§7]§f Revamped Safe zone screen the way sound screen has
+arc-ui.section.changelogv2desc.v1-0.007=§7[§a+§7]§f Fianlized configurations
+arc-ui.section.changelogv2desc.v1-0.008=§7[§a+§7]§f Added Theme ( Configurations )
+arc-ui.section.changelogv2desc.v1-0.009=§7[§a+§7]§f Added 129 Lawnmowers ( Configurations )
+arc-ui.section.changelogv2desc.v1-0.010=§7[§a+§7]§f Added Compact pause screen ( Configurations )
+arc-ui.section.changelogv2desc.v1-0.011=§7[§a+§7]§f Added Usable changelog in about screen
+arc-ui.section.changelogv2desc.v1-0.012=§7[§a+§7]§f Added Warning screen upon launching
+arc-ui.section.changelogv2desc.v1-0.013=§7[§a+§7]§f Added Highlights for pause screen arrow button
+arc-ui.section.changelogv2desc.v1-0.014=§7[§a+§7]§f Added Credits and Social media in about screen
+arc-ui.section.changelogv2desc.v1-0.015=§7[§a+§7]§f Added More supports for .lang format, allowing creators to change the language they want
+arc-ui.section.changelogv2desc.v1-0.016=§7[§a+§7]§f Added couple of elements that can be disabled on configurations
+arc-ui.section.changelogv2desc.v1-0.017=§7[§a+§7]§f Revamped About/Changelog screen with proper calgories
+arc-ui.section.changelogv2desc.v1-0.018=§7[§a+§7]§f Fixed the slider bar having incorrect color
+arc-ui.section.changelogv2desc.v1-0.019=§7[§a+§7]§f Fixed "Safe zone screen" slider icons where some has incorrect icons
+arc-ui.section.changelogv2desc.v1-0.020=§7[§a+§7]§f Fixed overlapping issues with pause screen
+arc-ui.section.changelogv2desc.v1-0.021=§7[§a+§7]§f Fixed issue where the game could potentially crashes by leaving and joining too fast
+arc-ui.section.changelogv2desc.v1-0.022=§7[§a+§7]§f Adjusted the highlight hover in settings and pause screen to fit visuality better
+arc-ui.section.changelogv2desc.v1-0.023=§7[§a+§7]§f ARC-UI/Arcdustry-UI requirements is now on "Settings>About/Changelog" Section
+arc-ui.section.changelogv2desc.v1-0.024=§7[§a+§7]§f Adjusted ALL glyphs/icons related to buttons and sliders into white due to theme support
+arc-ui.section.changelogv2desc.v1-0.025=§7[§a+§7]§f Changed ALL glyphs/icons related buttons and slider into white just for theming support
+arc-ui.section.changelogv2desc.v1-0.026=§7[§a+§7]§f Optimizations and stability
+
+## v1.0.1
+arc-ui.section.changelogv2desc.v1-0-1.001=§o× Released in - Mar 25, 2023
+arc-ui.section.changelogv2desc.v1-0-1.002=§o× Supported - 1.19.50+
+arc-ui.section.changelogv2desc.v1-0-1.003=§e× -- It's just a beginnings --
+arc-ui.section.changelogv2desc.v1-0-1.004=§e× Late update due to working on another UI
+arc-ui.section.changelogv2desc.v1-0-1.005=§7[§a+§7]§f Play screen tab now has icons and got theme support
+arc-ui.section.changelogv2desc.v1-0-1.006=§7[§a+§7]§f Pause screen (compact) now has theme support
+arc-ui.section.changelogv2desc.v1-0-1.007=§7[§a+§7]§f Theme now efficiently works all A-UI related screen now
+arc-ui.section.changelogv2desc.v1-0-1.008=§7[§e=§7]§f internal stuff
+arc-ui.section.changelogv2desc.v1-0-1.009=§7[§a+§7]§f Code optimization and cleaning
+arc-ui.section.changelogv2desc.v1-0-1.010=§7[§a+§7]§f Updated version requirements
+
+## v1.1
+arc-ui.section.changelogv2desc.v1-1.001=§o× Released in - Apr 29, 2023
+arc-ui.section.changelogv2desc.v1-1.002=§o× Supported - 1.19.60+
+arc-ui.section.changelogv2desc.v1-1.003=§e× -- Small update? --
+arc-ui.section.changelogv2desc.v1-1.004=§e× Cool stuff is there!
+arc-ui.section.changelogv2desc.v1-1.005=§7[§a+§7]§f Added Screen animations for normal screens
+arc-ui.section.changelogv2desc.v1-1.006=§7[§a+§7]§f Added additional back button for setting/play screen
+arc-ui.section.changelogv2desc.v1-1.007=§7[§a+§7]§f Improved Color theme system
+arc-ui.section.changelogv2desc.v1-1.008=§7[§a+§7]§f Added option to get rid of marketplace [CONFIG]
+arc-ui.section.changelogv2desc.v1-1.009=§7[§a+§7]§f Every screen has additional layout and visuals changes
+arc-ui.section.changelogv2desc.v1-1.010=§7[§a+§7]§f Updated to support 1.19.80-81
+arc-ui.section.changelogv2desc.v1-1.011=§7[§c-§7]§f Removed dialog's close button in response to new close button replacement
+arc-ui.section.changelogv2desc.v1-1.012=§7[§a+§7]§f Fixed couple of alignment issues
+arc-ui.section.changelogv2desc.v1-1.013=§7[§a+§7]§f Improved the stability of UI
+arc-ui.section.changelogv2desc.v1-1.014=§7[§a+§7]§f Fixed where animations sometime wouldn't work on couple devices
+arc-ui.section.changelogv2desc.v1-1.015=§7[§a+§7]§f Reworked few stuff
+arc-ui.section.changelogv2desc.v1-1.016=§7[§a+§7]§f Code improvements and optimization
+arc-ui.section.changelogv2desc.v1-1.017=§7[§a+§7]§f Updated Version requirements
+arc-ui.section.changelogv2desc.v1-1.018=§7[§a+§7]§f Renamed and fixed misspelling in en lang
+
+## v1.2
+arc-ui.section.changelogv2desc.v1-2.001=§o× Released in - May 18, 2023
+arc-ui.section.changelogv2desc.v1-2.002=§o× Supported - 1.19.60+
+arc-ui.section.changelogv2desc.v1-2.003=§e× -- Large update...???? --
+arc-ui.section.changelogv2desc.v1-2.004=§e× Probably large update i suppose.
+arc-ui.section.changelogv2desc.v1-2.005=§7[§a+§7]§f New Trailer for the UI once for all!
+arc-ui.section.changelogv2desc.v1-2.006=§7[§a+§7]§f Updated Accessibility Section with 2 new slider from 1.19.82/83
+arc-ui.section.changelogv2desc.v1-2.007=§7[§a+§7]§f Updated structure of UI folders
+arc-ui.section.changelogv2desc.v1-2.008=§7[§a+§7]§f Updated Back button icon
+arc-ui.section.changelogv2desc.v1-2.009=§7[§a+§7]§f Updated the UI layouts
+arc-ui.section.changelogv2desc.v1-2.010=§7[§a+§7]§f Updated About Section
+arc-ui.section.changelogv2desc.v1-2.011=§7[§a+§7]§f Updated Settings to 1.19.83
+arc-ui.section.changelogv2desc.v1-2.012=§7[§a+§7]§f Revamped Play Screen with proper layout and sections
+arc-ui.section.changelogv2desc.v1-2.013=§7[§a+§7]§f Added Changelog v2 (rip v1, in fact you're seeing this right now!)
+arc-ui.section.changelogv2desc.v1-2.014=§7[§a+§7]§f Added PlanetMinecraft Profile/Icon in response of Arcdustry-UI being uploaded in PlanetMinecraft!
+arc-ui.section.changelogv2desc.v1-2.015=§7[§c-§7]§f Removed Version requirements, instead are now reimplemented in Changelog v2
+arc-ui.section.changelogv2desc.v1-2.016=§7[§c-§7]§f Removed Build date, instead are now reimplemented in Changelog v2
+arc-ui.section.changelogv2desc.v1-2.017=§7[§a+§7]§f Fixed animations being wanky
+arc-ui.section.changelogv2desc.v1-2.018=§7[§a+§7]§f Fixed the issue where sometimes pause screen may crash the game
+arc-ui.section.changelogv2desc.v1-2.019=§7[§a+§7]§f Fixed another alignment issues, again
+arc-ui.section.changelogv2desc.v1-2.020=§7[§a+§7]§f Fixed being unable to use tab with controller in play screen
+arc-ui.section.changelogv2desc.v1-2.021=§7[§a+§7]§f Fixed grammar in couple of settings sections
+arc-ui.section.changelogv2desc.v1-2.022=§7[§a+§7]§f Improvements to UI stability
+arc-ui.section.changelogv2desc.v1-2.023=§7[§a+§7]§f Improved the loading screen animations
+arc-ui.section.changelogv2desc.v1-2.024=§7[§a+§7]§f Improved the warning dialog
+arc-ui.section.changelogv2desc.v1-2.025=§7[§a+§7]§f Decreased the UI loading delays
+arc-ui.section.changelogv2desc.v1-2.026=§7[§a+§7]§f UI is now abit smaller for large screen usage
+arc-ui.section.changelogv2desc.v1-2.027=§7[§a+§7]§f Code Optimizations and cleaning
+arc-ui.section.changelogv2desc.v1-2.028=§7[§a+§7]§f UI file path is changed to probably feel less empty
+arc-ui.section.changelogv2desc.v1-2.029=§7[§a+§7]§f Added date next to version


### PR DESCRIPTION
- All changelog remains untranslated: too long and not necessary (?).

The following strings are also untranslated because they are defined in JSON files:
- The waning about the font and Pocket UI.
- In SETTINGS screen: “Settings”, “Utilities” and “Current logged as”.
- In PLAY screen: “Play”, “Back "play screen” and “control page”.
- In LOADING screen: “loading”.